### PR TITLE
Add default:dirt_with_dry_grass to acacia_biome.

### DIFF
--- a/biome_defs.lua
+++ b/biome_defs.lua
@@ -91,7 +91,7 @@ moretrees.willow_biome = {
 }
 
 moretrees.acacia_biome = {
-	surface = { "default:dirt_with_grass", "default:desert_sand" },
+	surface = { "default:dirt_with_grass", "default:dirt_with_dry_grass", "default:desert_sand" },
 	avoid_nodes = moretrees.avoidnodes,
 	avoid_radius = 15,
 	seed_diff = 1,


### PR DESCRIPTION
This allows moretrees:acacia to spawn in Savanna biomes.